### PR TITLE
Historyモデルを追加する

### DIFF
--- a/app/models/blance.rb
+++ b/app/models/blance.rb
@@ -1,4 +1,6 @@
 class Blance < ApplicationRecord
+  has_one :history_order, dependent: :destroy
+
   default_scope -> { order(date: :desc) }
 
   validates :date, presence: true

--- a/app/models/blance.rb
+++ b/app/models/blance.rb
@@ -1,5 +1,5 @@
 class Blance < ApplicationRecord
-  has_one :history_order, dependent: :destroy
+  has_one :history, class_name: "HistoryOrder", dependent: :destroy
 
   default_scope -> { order(date: :desc) }
 
@@ -30,5 +30,10 @@ class Blance < ApplicationRecord
     recovery_saving = self.recovery_saving.to_i * rate
     result = recovery_money - investment_money + recovery_saving - investment_saving
     result.round
+  end
+
+  def histories
+    return nil if history.nil?
+    history.sort_order
   end
 end

--- a/app/models/blance.rb
+++ b/app/models/blance.rb
@@ -34,6 +34,7 @@ class Blance < ApplicationRecord
 
   def histories
     return nil if history.nil?
+
     history.sort_order
   end
 end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,0 +1,2 @@
+class History < ApplicationRecord
+end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,4 +1,6 @@
 class History < ApplicationRecord
+  belongs_to :history_order
+
   validates :game_count, presence: true, numericality: { less_than: 2**31 }
   validates :chance, presence: true, length: { maximum: 100 }
   validates :investment, presence: true, length: { maximum: 100 }

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,2 +1,6 @@
 class History < ApplicationRecord
+  validates :game_count, presence: true, numericality: { less_than: 2**31 }
+  validates :chance, presence: true, length: { maximum: 100 }
+  validates :investment, presence: true, length: { maximum: 100 }
+  validates :memo, length: { maximum: 1000 }
 end

--- a/app/models/history_order.rb
+++ b/app/models/history_order.rb
@@ -1,4 +1,4 @@
 class HistoryOrder < ApplicationRecord
   ORDER_REGEX = /(\d+,)+\d+\Z/
-  validates :order, presence: true, length: { maximum: 1000 }, format: { with: ORDER_REGEX }
+  validates :order, length: { maximum: 1000 }, format: { with: ORDER_REGEX }, allow_blank: true
 end

--- a/app/models/history_order.rb
+++ b/app/models/history_order.rb
@@ -1,2 +1,4 @@
 class HistoryOrder < ApplicationRecord
+  ORDER_REGEX = /(\d+,)+\d+\Z/
+  validates :order, presence: true, length: { maximum: 1000 }, format: { with: ORDER_REGEX }
 end

--- a/app/models/history_order.rb
+++ b/app/models/history_order.rb
@@ -4,4 +4,10 @@ class HistoryOrder < ApplicationRecord
 
   ORDER_REGEX = /(\d+,)+\d+\Z/
   validates :order, length: { maximum: 1000 }, format: { with: ORDER_REGEX }, allow_blank: true
+
+  def sort_order
+    return histories if order.blank?
+    order_array = order.split(',').map(&:to_i)
+    histories.sort_by { |history| order_array.index(history.id) }
+  end
 end

--- a/app/models/history_order.rb
+++ b/app/models/history_order.rb
@@ -1,4 +1,6 @@
 class HistoryOrder < ApplicationRecord
+  has_many :histories, dependent: :destroy
+
   ORDER_REGEX = /(\d+,)+\d+\Z/
   validates :order, length: { maximum: 1000 }, format: { with: ORDER_REGEX }, allow_blank: true
 end

--- a/app/models/history_order.rb
+++ b/app/models/history_order.rb
@@ -7,6 +7,7 @@ class HistoryOrder < ApplicationRecord
 
   def sort_order
     return histories if order.blank?
+
     order_array = order.split(',').map(&:to_i)
     histories.sort_by { |history| order_array.index(history.id) }
   end

--- a/app/models/history_order.rb
+++ b/app/models/history_order.rb
@@ -1,0 +1,2 @@
+class HistoryOrder < ApplicationRecord
+end

--- a/app/models/history_order.rb
+++ b/app/models/history_order.rb
@@ -1,4 +1,5 @@
 class HistoryOrder < ApplicationRecord
+  belongs_to :blance
   has_many :histories, dependent: :destroy
 
   ORDER_REGEX = /(\d+,)+\d+\Z/

--- a/db/migrate/20231119185822_create_histories.rb
+++ b/db/migrate/20231119185822_create_histories.rb
@@ -1,0 +1,12 @@
+class CreateHistories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :histories do |t|
+      t.integer :game_count, null: false, limit: 4
+      t.string :chance, null: false, limit: 100
+      t.string :investment, null: false, limit: 100
+      t.text :memo, limit: 1000
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231121170855_create_history_orders.rb
+++ b/db/migrate/20231121170855_create_history_orders.rb
@@ -1,0 +1,9 @@
+class CreateHistoryOrders < ActiveRecord::Migration[7.0]
+  def change
+    create_table :history_orders do |t|
+      t.string :order, null: false, limit: 1000
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231122121402_change_column_to_history_order.rb
+++ b/db/migrate/20231122121402_change_column_to_history_order.rb
@@ -1,0 +1,5 @@
+class ChangeColumnToHistoryOrder < ActiveRecord::Migration[7.0]
+  def change
+    change_column :history_orders, :order, :string, null: true, limit: 1000
+  end
+end

--- a/db/migrate/20231122122614_add_history_order_to_histories.rb
+++ b/db/migrate/20231122122614_add_history_order_to_histories.rb
@@ -1,0 +1,5 @@
+class AddHistoryOrderToHistories < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :histories, :history_order, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20231122132434_add_blance_to_history_order.rb
+++ b/db/migrate/20231122132434_add_blance_to_history_order.rb
@@ -1,0 +1,5 @@
+class AddBlanceToHistoryOrder < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :history_orders, :blance, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_21_170855) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_22_121402) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,7 +39,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_21_170855) do
   end
 
   create_table "history_orders", force: :cascade do |t|
-    t.string "order", limit: 1000, null: false
+    t.string "order", limit: 1000
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_27_152346) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_19_185822) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_27_152346) do
     t.float "rate"
     t.string "store", limit: 1000
     t.text "note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "histories", force: :cascade do |t|
+    t.integer "game_count", null: false
+    t.string "chance", limit: 100, null: false
+    t.string "investment", limit: 100, null: false
+    t.text "memo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_22_122614) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_22_132434) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,7 +44,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_22_122614) do
     t.string "order", limit: 1000
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "blance_id", null: false
+    t.index ["blance_id"], name: "index_history_orders_on_blance_id"
   end
 
   add_foreign_key "histories", "history_orders"
+  add_foreign_key "history_orders", "blances"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_19_185822) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_21_170855) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -34,6 +34,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_19_185822) do
     t.string "chance", limit: 100, null: false
     t.string "investment", limit: 100, null: false
     t.text "memo"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "history_orders", force: :cascade do |t|
+    t.string "order", limit: 1000, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_22_121402) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_22_122614) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -36,6 +36,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_22_121402) do
     t.text "memo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "history_order_id", null: false
+    t.index ["history_order_id"], name: "index_histories_on_history_order_id"
   end
 
   create_table "history_orders", force: :cascade do |t|
@@ -44,4 +46,5 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_22_121402) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "histories", "history_orders"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
 
-Blance.create!(
+blance = Blance.create!(
   date: Date.parse("2023-10-27"),
   category: "スロット",
   name: "スマスロ北斗の拳",
@@ -33,3 +33,35 @@ Blance.create!(
   note: "エヴァの台が空いていたので座った。",
 )
 puts "Blance count: #{Blance.count}"
+
+history_order = blance.create_history!
+puts "HistoryOrder count: #{HistoryOrder.count}"
+
+history1 = history_order.histories.create!(
+  game_count: 3,
+  chance: "BB",
+  investment: "3000円",
+  memo: "ボーナス3回",
+)
+puts "History count: #{History.count}"
+
+history2 = history_order.histories.create!(
+  game_count: 2,
+  chance: "RB",
+  investment: "2000円",
+  memo: "ボーナス2回",
+)
+puts "History count: #{History.count}"
+
+history3 = history_order.histories.create!(
+  game_count: 1,
+  chance: "BB",
+  investment: "1000円",
+  memo: "ボーナス1回",
+)
+puts "History count: #{History.count}"
+
+history_ids = [history3.id, history2.id, history1.id]
+history_order.order = history_ids.join(",")
+history_order.save!
+puts "history_order updated"

--- a/test/fixtures/histories.yml
+++ b/test/fixtures/histories.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  game_count: 160
+  chance: BB
+  investment: 4000円
+  memo: チェリー重複
+
+two:
+  game_count: 10
+  chance: RB
+  investment: 1000円
+  memo: 単独

--- a/test/fixtures/histories.yml
+++ b/test/fixtures/histories.yml
@@ -13,3 +13,27 @@ two:
   investment: 1000円
   memo: 単独
   history_order: two
+
+id1:
+  id: 1
+  game_count: 1
+  chance: BB
+  investment: 1000円
+  memo: 単独
+  history_order: sort_order
+
+id2:
+  id: 2
+  game_count: 2
+  chance: BB
+  investment: 2000円
+  memo: 単独
+  history_order: sort_order
+
+id3:
+  id: 3
+  game_count: 3
+  chance: BB
+  investment: 3000円
+  memo: 単独
+  history_order: sort_order

--- a/test/fixtures/histories.yml
+++ b/test/fixtures/histories.yml
@@ -5,9 +5,11 @@ one:
   chance: BB
   investment: 4000円
   memo: チェリー重複
+  history_order: one
 
 two:
   game_count: 10
   chance: RB
   investment: 1000円
   memo: 単独
+  history_order: two

--- a/test/fixtures/history_orders.yml
+++ b/test/fixtures/history_orders.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  order: "1,2,3,4,5"
+
+two:
+  order: "6,7,8,9,10"

--- a/test/fixtures/history_orders.yml
+++ b/test/fixtures/history_orders.yml
@@ -1,9 +1,13 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  order: "1,2,3,4,5"
+  order: ""
   blance: one
 
 two:
-  order: "6,7,8,9,10"
+  order: ""
   blance: two
+
+sort_order:
+  order: "3,1,2"
+  blance: most_recent

--- a/test/fixtures/history_orders.yml
+++ b/test/fixtures/history_orders.yml
@@ -2,6 +2,8 @@
 
 one:
   order: "1,2,3,4,5"
+  blance: one
 
 two:
   order: "6,7,8,9,10"
+  blance: two

--- a/test/models/blance_test.rb
+++ b/test/models/blance_test.rb
@@ -92,6 +92,18 @@ class BlanceTest < ActiveSupport::TestCase
     assert_not @blance.valid?
   end
 
+  test "associated history_orders should be valid" do
+    @blance.save
+    assert @blance.history_order
+  end
+
+  test "associated history_orders should be destroyed" do
+    @blance.save
+    assert_difference "HistoryOrder.count", -1 do
+      @blance.destroy
+    end
+  end
+
   test "result() should be correct (rate: 4.0)" do
     blance = Blance.new(
       investment_money: 24_000,

--- a/test/models/blance_test.rb
+++ b/test/models/blance_test.rb
@@ -94,7 +94,7 @@ class BlanceTest < ActiveSupport::TestCase
 
   test "associated history_orders should be valid" do
     @blance.save
-    assert @blance.history_order
+    assert @blance.history
   end
 
   test "associated history_orders should be destroyed" do
@@ -135,5 +135,16 @@ class BlanceTest < ActiveSupport::TestCase
       rate: nil
     )
     assert_equal 0, blance.result
+  end
+
+  test "histories() should be alias for history_order.sort_order()" do
+    most_recent = blances(:most_recent)
+    history = most_recent.history
+    assert_equal history.sort_order, most_recent.histories
+  end
+
+  test "histories() should return nil if history does not exist" do
+    @blance.history = nil
+    assert_nil @blance.histories
   end
 end

--- a/test/models/history_order_test.rb
+++ b/test/models/history_order_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class HistoryOrderTest < ActiveSupport::TestCase
+  test "should be true" do
+    assert true
+  end
+end

--- a/test/models/history_order_test.rb
+++ b/test/models/history_order_test.rb
@@ -1,7 +1,46 @@
 require "test_helper"
 
 class HistoryOrderTest < ActiveSupport::TestCase
-  test "should be true" do
-    assert true
+  def setup
+    @history_order = history_orders(:one)
+  end
+
+  test "should be valid" do
+    assert @history_order.valid?
+  end
+
+  test "should be invalid" do
+    assert HistoryOrder.new.invalid?
+  end
+
+  test "order should be present" do
+    @history_order.order = "     "
+    assert_not @history_order.valid?
+  end
+
+  test "order should not be too long" do
+    @history_order.order = "a" * 1001
+    assert_not @history_order.valid?
+  end
+
+  test "order should be valid format" do
+    valid_orders = %w[1,2,3 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]
+    valid_orders.each do |valid_order|
+      @history_order.order = valid_order
+      assert @history_order.valid?, "#{valid_order.inspect} should be valid"
+    end
+  end
+
+  test "order should be invalid format" do
+    invalid_orders = %w[
+      hogebar
+      1, 2, 3, 4, 5
+      6,7,8,9,10,11,
+      12,13, 14,15, 16
+    ]
+    invalid_orders.each do |invalid_order|
+      @history_order.order = invalid_order
+      assert @history_order.invalid?, "#{invalid_order.inspect} should be invalid"
+    end
   end
 end

--- a/test/models/history_order_test.rb
+++ b/test/models/history_order_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class HistoryOrderTest < ActiveSupport::TestCase
   def setup
     @history_order = history_orders(:one)
+    @sort_order = history_orders(:sort_order)
   end
 
   test "should be valid" do
@@ -55,5 +56,15 @@ class HistoryOrderTest < ActiveSupport::TestCase
     assert_difference "History.count", -1 do
       @history_order.destroy
     end
+  end
+
+  test "sort_order() returns an arbitrarily ordered histories" do
+    order = @sort_order.order
+    assert_equal order.split(",").map(&:to_i), @sort_order.sort_order.map(&:id)
+  end
+
+  test "sort_order() returns histories when order is nil" do
+    @sort_order.order = nil
+    assert_equal @sort_order.histories, @sort_order.sort_order
   end
 end

--- a/test/models/history_order_test.rb
+++ b/test/models/history_order_test.rb
@@ -24,11 +24,11 @@ class HistoryOrderTest < ActiveSupport::TestCase
   end
 
   test "order should be invalid format" do
-    invalid_orders = %w[
-      hogebar
-      1, 2, 3, 4, 5
-      6,7,8,9,10,11,
-      12,13, 14,15, 16
+    invalid_orders = [
+      "hogebar",
+      "1, 2, 3, 4, 5",
+      "6,7,8,9,10,11,",
+      "12,13, 14,15, 16"
     ]
     invalid_orders.each do |invalid_order|
       @history_order.order = invalid_order

--- a/test/models/history_order_test.rb
+++ b/test/models/history_order_test.rb
@@ -40,4 +40,16 @@ class HistoryOrderTest < ActiveSupport::TestCase
     @history_order.order = "     "
     assert @history_order.valid?
   end
+
+  test "associated histories should be valid" do
+    @history_order.save
+    assert @history_order.histories
+  end
+
+  test "associated history should be destroyed" do
+    @history_order.save
+    assert_difference "History.count", -1 do
+      @history_order.destroy
+    end
+  end
 end

--- a/test/models/history_order_test.rb
+++ b/test/models/history_order_test.rb
@@ -7,15 +7,7 @@ class HistoryOrderTest < ActiveSupport::TestCase
 
   test "should be valid" do
     assert @history_order.valid?
-  end
-
-  test "should be invalid" do
-    assert HistoryOrder.new.invalid?
-  end
-
-  test "order should be present" do
-    @history_order.order = "     "
-    assert_not @history_order.valid?
+    assert HistoryOrder.new.valid?
   end
 
   test "order should not be too long" do
@@ -42,5 +34,10 @@ class HistoryOrderTest < ActiveSupport::TestCase
       @history_order.order = invalid_order
       assert @history_order.invalid?, "#{invalid_order.inspect} should be invalid"
     end
+  end
+
+  test "order allow blank" do
+    @history_order.order = "     "
+    assert @history_order.valid?
   end
 end

--- a/test/models/history_order_test.rb
+++ b/test/models/history_order_test.rb
@@ -7,7 +7,6 @@ class HistoryOrderTest < ActiveSupport::TestCase
 
   test "should be valid" do
     assert @history_order.valid?
-    assert HistoryOrder.new.valid?
   end
 
   test "order should not be too long" do
@@ -39,6 +38,11 @@ class HistoryOrderTest < ActiveSupport::TestCase
   test "order allow blank" do
     @history_order.order = "     "
     assert @history_order.valid?
+  end
+
+  test "associated blance should be valid" do
+    @history_order.save
+    assert @history_order.blance
   end
 
   test "associated histories should be valid" do

--- a/test/models/history_test.rb
+++ b/test/models/history_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class HistoryTest < ActiveSupport::TestCase
+  def setup
+    @history = histories(:one)
+  end
+
+  test "should be valid" do
+    assert @history.valid?
+  end
+end

--- a/test/models/history_test.rb
+++ b/test/models/history_test.rb
@@ -52,4 +52,9 @@ class HistoryTest < ActiveSupport::TestCase
     @history.memo = "a" * 1001
     assert_not @history.valid?
   end
+
+  test "associated history_order should be valid" do
+    @history.save
+    assert @history.history_order
+  end
 end

--- a/test/models/history_test.rb
+++ b/test/models/history_test.rb
@@ -8,4 +8,48 @@ class HistoryTest < ActiveSupport::TestCase
   test "should be valid" do
     assert @history.valid?
   end
+
+  test "should be invalid" do
+    assert History.new.invalid?
+  end
+
+  test "game_count should be present" do
+    @history.game_count = "     "
+    assert_not @history.valid?
+  end
+
+  test "game_count should be integer" do
+    @history.game_count = "hogebar"
+    assert_not @history.valid?
+  end
+
+  test "game_count should not be too long" do
+    @history.game_count = (2**31) + 1
+    assert_not @history.valid?
+  end
+
+  test "chance should be present" do
+    @history.chance = "     "
+    assert_not @history.valid?
+  end
+
+  test "chance should not be too long" do
+    @history.chance = "a" * 101
+    assert_not @history.valid?
+  end
+
+  test "investment should be present" do
+    @history.investment = "     "
+    assert_not @history.valid?
+  end
+
+  test "investment should not be too long" do
+    @history.investment = "a" * 101
+    assert_not @history.valid?
+  end
+
+  test "memo should not be too long" do
+    @history.memo = "a" * 1001
+    assert_not @history.valid?
+  end
 end

--- a/test/system/blances_test.rb
+++ b/test/system/blances_test.rb
@@ -88,11 +88,11 @@ class BlancesTest < ApplicationSystemTestCase
     click_on I18n.t("blances.edit.button_text")
     assert_selector "div#error_explanation"
     # valid input
-    fill_in I18n.t("activerecord.attributes.blance.date"), with: Date.today
+    fill_in I18n.t("activerecord.attributes.blance.date"), with: Time.zone.today
     click_on I18n.t("blances.edit.button_text")
     # check redirect
     assert_selector "div#flash_notice", text: I18n.t("blances.update.notice")
-    assert_text I18n.l(Date.today)
+    assert_text I18n.l(Time.zone.today)
   end
 
   test "destroying a Blance" do


### PR DESCRIPTION
**主な変更内容**

- Historyモデルの追加
- HistoryOrderモデルの追加

**イシュー番号**

Issue: #35

**チェックリスト**

- [x] `rails console`での`History, HistoryOrder`モデルの作成
- [x] `history_order.sort_order, blance.histories`のメソッドの実行

問題がなければマージをお願いします。