### PR TITLE
履歴モデルの関連付けの修正

### DIFF
--- a/app/models/blance.rb
+++ b/app/models/blance.rb
@@ -1,5 +1,6 @@
 class Blance < ApplicationRecord
-  has_one :history, class_name: "HistoryOrder", dependent: :destroy
+  has_one :history_order, dependent: :destroy
+  has_many :histories, dependent: :destroy
 
   default_scope -> { order(date: :desc) }
 
@@ -32,9 +33,10 @@ class Blance < ApplicationRecord
     result.round
   end
 
-  def histories
-    return nil if history.nil?
+  def sort_histories
+    return histories if history_order.order.blank?
 
-    history.sort_order
+    order_array = history_order.order.split(',').map(&:to_i)
+    histories.sort_by { |history| order_array.index(history.id) }
   end
 end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,5 +1,5 @@
 class History < ApplicationRecord
-  belongs_to :history_order
+  belongs_to :blance
 
   validates :game_count, presence: true, numericality: { less_than: 2**31 }
   validates :chance, presence: true, length: { maximum: 100 }

--- a/app/models/history_order.rb
+++ b/app/models/history_order.rb
@@ -1,14 +1,6 @@
 class HistoryOrder < ApplicationRecord
   belongs_to :blance
-  has_many :histories, dependent: :destroy
 
   ORDER_REGEX = /(\d+,)+\d+\Z/
   validates :order, length: { maximum: 1000 }, format: { with: ORDER_REGEX }, allow_blank: true
-
-  def sort_order
-    return histories if order.blank?
-
-    order_array = order.split(',').map(&:to_i)
-    histories.sort_by { |history| order_array.index(history.id) }
-  end
 end

--- a/db/migrate/20231125144318_change_history_order_id_to_history.rb
+++ b/db/migrate/20231125144318_change_history_order_id_to_history.rb
@@ -1,0 +1,6 @@
+class ChangeHistoryOrderIdToHistory < ActiveRecord::Migration[7.0]
+  def change
+    remove_reference :histories, :history_order, null: false, foreign_key: true
+    add_reference :histories, :blance, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_22_132434) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_25_144318) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -36,8 +36,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_22_132434) do
     t.text "memo"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "history_order_id", null: false
-    t.index ["history_order_id"], name: "index_histories_on_history_order_id"
+    t.bigint "blance_id", null: false
+    t.index ["blance_id"], name: "index_histories_on_blance_id"
   end
 
   create_table "history_orders", force: :cascade do |t|
@@ -48,6 +48,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_22_132434) do
     t.index ["blance_id"], name: "index_history_orders_on_blance_id"
   end
 
-  add_foreign_key "histories", "history_orders"
+  add_foreign_key "histories", "blances"
   add_foreign_key "history_orders", "blances"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,10 +34,10 @@ Blance.create!(
 )
 puts "Blance count: #{Blance.count}"
 
-history_order = blance.create_history!
+blance.create_history_order!
 puts "HistoryOrder count: #{HistoryOrder.count}"
 
-history1 = history_order.histories.create!(
+history1 = blance.histories.create!(
   game_count: 3,
   chance: "BB",
   investment: "3000円",
@@ -45,7 +45,7 @@ history1 = history_order.histories.create!(
 )
 puts "History count: #{History.count}"
 
-history2 = history_order.histories.create!(
+history2 = blance.histories.create!(
   game_count: 2,
   chance: "RB",
   investment: "2000円",
@@ -53,7 +53,7 @@ history2 = history_order.histories.create!(
 )
 puts "History count: #{History.count}"
 
-history3 = history_order.histories.create!(
+history3 = blance.histories.create!(
   game_count: 1,
   chance: "BB",
   investment: "1000円",
@@ -62,6 +62,6 @@ history3 = history_order.histories.create!(
 puts "History count: #{History.count}"
 
 history_ids = [history3.id, history2.id, history1.id]
-history_order.order = history_ids.join(",")
-history_order.save!
+blance.history_order.order = history_ids.join(",")
+blance.history_order.save!
 puts "history_order updated"

--- a/test/fixtures/histories.yml
+++ b/test/fixtures/histories.yml
@@ -1,26 +1,19 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
+  id: 1
   game_count: 160
   chance: BB
   investment: 4000円
   memo: チェリー重複
-  history_order: one
+  blance: one
 
 two:
   game_count: 10
   chance: RB
   investment: 1000円
   memo: 単独
-  history_order: two
-
-id1:
-  id: 1
-  game_count: 1
-  chance: BB
-  investment: 1000円
-  memo: 単独
-  history_order: sort_order
+  blance: two
 
 id2:
   id: 2
@@ -28,7 +21,7 @@ id2:
   chance: BB
   investment: 2000円
   memo: 単独
-  history_order: sort_order
+  blance: one
 
 id3:
   id: 3
@@ -36,4 +29,4 @@ id3:
   chance: BB
   investment: 3000円
   memo: 単独
-  history_order: sort_order
+  blance: one

--- a/test/fixtures/history_orders.yml
+++ b/test/fixtures/history_orders.yml
@@ -1,13 +1,9 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  order: ""
+  order: "3,1,2"
   blance: one
 
 two:
   order: ""
   blance: two
-
-sort_order:
-  order: "3,1,2"
-  blance: most_recent

--- a/test/models/blance_test.rb
+++ b/test/models/blance_test.rb
@@ -92,14 +92,22 @@ class BlanceTest < ActiveSupport::TestCase
     assert_not @blance.valid?
   end
 
-  test "associated history_orders should be valid" do
-    @blance.save
-    assert @blance.history
+  test "associated history_order should be valid" do
+    assert @blance.history_order
   end
 
-  test "associated history_orders should be destroyed" do
-    @blance.save
+  test "associated history_order should be destroyed" do
     assert_difference "HistoryOrder.count", -1 do
+      @blance.destroy
+    end
+  end
+
+  test "associated histories should be valid" do
+    assert @blance.histories
+  end
+
+  test "associated histories should be destroyed" do
+    assert_difference "History.count", -3 do
       @blance.destroy
     end
   end
@@ -137,14 +145,13 @@ class BlanceTest < ActiveSupport::TestCase
     assert_equal 0, blance.result
   end
 
-  test "histories() should be alias for history_order.sort_order()" do
-    most_recent = blances(:most_recent)
-    history = most_recent.history
-    assert_equal history.sort_order, most_recent.histories
+  test "sort_histories() returns an arbitrarily ordered histories" do
+    order = @blance.history_order.order
+    assert_equal order.split(",").map(&:to_i), @blance.sort_histories.map(&:id)
   end
 
-  test "histories() should return nil if history does not exist" do
-    @blance.history = nil
-    assert_nil @blance.histories
+  test "sort_histories() returns histories when order is nil" do
+    @blance.history_order.order = nil
+    assert_equal @blance.histories, @blance.sort_histories
   end
 end

--- a/test/models/history_order_test.rb
+++ b/test/models/history_order_test.rb
@@ -3,7 +3,6 @@ require "test_helper"
 class HistoryOrderTest < ActiveSupport::TestCase
   def setup
     @history_order = history_orders(:one)
-    @sort_order = history_orders(:sort_order)
   end
 
   test "should be valid" do
@@ -44,27 +43,5 @@ class HistoryOrderTest < ActiveSupport::TestCase
   test "associated blance should be valid" do
     @history_order.save
     assert @history_order.blance
-  end
-
-  test "associated histories should be valid" do
-    @history_order.save
-    assert @history_order.histories
-  end
-
-  test "associated history should be destroyed" do
-    @history_order.save
-    assert_difference "History.count", -1 do
-      @history_order.destroy
-    end
-  end
-
-  test "sort_order() returns an arbitrarily ordered histories" do
-    order = @sort_order.order
-    assert_equal order.split(",").map(&:to_i), @sort_order.sort_order.map(&:id)
-  end
-
-  test "sort_order() returns histories when order is nil" do
-    @sort_order.order = nil
-    assert_equal @sort_order.histories, @sort_order.sort_order
   end
 end

--- a/test/models/history_test.rb
+++ b/test/models/history_test.rb
@@ -53,8 +53,7 @@ class HistoryTest < ActiveSupport::TestCase
     assert_not @history.valid?
   end
 
-  test "associated history_order should be valid" do
-    @history.save
-    assert @history.history_order
+  test "associated blance should be valid" do
+    assert @history.blance
   end
 end


### PR DESCRIPTION
**主な変更内容**

- `Blance, HistoryOrder, History`モデルの関連付けの関係
- `histories`レコードの`history_order_id`カラムを削除し、`blance_order_id`カラムを追加
- 上記の変更を行った際のコードの修正

**イシュー番号**

Issue: https://github.com/ittokunvim/pachislot-syusi/issues/35#issuecomment-1826348258

**チェックリスト**

- [x] `blance.sort_histories`メソッドの追加
- [x] `history_order.sort_order`メソッドの削除
