### PR TITLE
遊技履歴ページにスタイルを追加

### DIFF
--- a/app/assets/stylesheets/blances.scss
+++ b/app/assets/stylesheets/blances.scss
@@ -42,7 +42,12 @@
           }
           &:nth-child(even) {
             background-color: $list-even-background-color;
-            border-top: 1px solid $border-color; }
+            border-top: 1px solid $border-color;
+            border-bottom: 1px solid $border-color;
+            &:last-child {
+              border-bottom: none;
+            }
+          }
         }
       }
     }
@@ -103,6 +108,7 @@
   .links {
     font-size: 0.9rem;
     display: inline-block;
+    margin-top: 1rem;
     border: 1px solid $border-color;
     border-radius: 0.5em;
 
@@ -137,6 +143,11 @@
         &.delete:hover {
           color: white;
           background-color: $blances-show-delete-background-color;
+        }
+
+        &.history:hover {
+          color: white;
+          background-color: $blances-show-history-background-color;
         }
 
         &.back:hover {

--- a/app/assets/stylesheets/histories.scss
+++ b/app/assets/stylesheets/histories.scss
@@ -64,15 +64,41 @@
   form {
     padding: 1em;
     border: 1px solid $border-color;
+    border-radius: 0.5em;
     .form_group {
       display: flex;
       flex-direction: column;
       gap: 0.2em;
-      margin-top: 0.5em;
-      // label {}
-      // input {}
-      // textarea {}
-      // input[type="submit"] {}
+      margin-bottom: 0.5em;
+      label {
+        font-size: 0.8rem;
+      }
+      input,
+      textarea {
+        font-size: 1rem;
+        box-sizing: border-box;
+        width: 100%;
+        padding: 0.25em;
+        border: 1px solid $border-color;
+        border-radius: 0.2em;
+        letter-spacing: 1px;
+        word-spacing: 2px;
+        background-color: $base-background-color;
+        color: $base-color;
+      }
+    }
+    textarea {
+      height: 10em;
+    }
+    input[type="submit"] {
+      cursor: pointer;
+      font-size: 0.8rem;
+      font-weight: bold;
+      padding: 0.5em 1em;
+      border: 1px solid black;
+      border-radius: 0.5em;
+      background-color: $blances-form-submit-background-color;
+      color: white;
     }
   }
 }

--- a/app/assets/stylesheets/histories.scss
+++ b/app/assets/stylesheets/histories.scss
@@ -52,8 +52,17 @@
       border: 1px solid $border-color;
     }
   }
-  .histories__form {
-    padding: 1em 0;
+  .new_history {
+    margin-top: 1rem;
+    a {
+      display: inline-block;
+      color: white;
+      background-color: $blances-form-submit-background-color;
+      text-decoration: none;
+      padding: 1em;
+      border: 1px solid black;
+      border-radius: 0.5em;
+    }
   }
 }
 

--- a/app/assets/stylesheets/histories.scss
+++ b/app/assets/stylesheets/histories.scss
@@ -4,36 +4,52 @@
 // index
 //
 .histories__index {
+  font-size: 0.8rem;
+  overflow-x: auto;
   padding: 1rem;
-  .list {
-    table {
+  table {
+    width: max-content;
+    border-collapse: collapse;
+    th,
+    td {
+      min-width: 80px;
+      max-width: 200px;
+      padding: 0.5em;
       border: 1px solid $border-color;
-      border-collapse: collapse;
-      th {
-        padding: 0.5em;
-        border: 1px solid $border-color;
-      }
-      td {
-        padding: 0.5em;
-        border: 1px solid $border-color;
-      }
-      td:last-child {
-        ul {
-          display: flex;
-          flex-direction: column;
-          line-height: 2;
-          a {
-            color: $link-color;
-            text-decoration: none;
-            &:hover {
-              text-decoration: underline;
-            }
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    td:last-child {
+      padding: 0;
+      ul {
+        display: flex;
+        flex-direction: column;
+        margin: 0;
+        padding: 0;
+        line-height: 2;
+        a {
+          color: $link-color;
+          text-decoration: none;
+          padding: 0.25em 0.5em;
+          &:hover {
+            text-decoration: underline;
+          }
+          &:nth-child(even) {
+            background-color: $list-even-background-color;
+            border-top: 1px solid $border-color;
           }
         }
       }
     }
+  }
+  .no_history {
+    margin: 0 auto;
+    text-align: center;
     p {
-      text-align: center;
+      display: inline-block;
+      padding: 1em;
+      border: 1px solid $border-color;
     }
   }
   .histories__form {

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -11,6 +11,7 @@ $shared-error-explanation-background-color: #ffc0cb;
 $blances-show-headline-background-color: #eeeeee;
 $blances-show-edit-background-color: #32cd32;
 $blances-show-delete-background-color: #ff4500;
+$blances-show-history-background-color: #daa520;
 $blances-show-back-background-color: #808080;
 $blances-form-border-color: #333333;
 $blances-form-submit-background-color: #32cd32;

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -20,7 +20,6 @@ class HistoriesController < ApplicationController
     if @history.save
       redirect_to blance_histories_url(@blance), notice: t(".notice")
     else
-      redirect_to blance_histories_url(@blance), alert: t(".alert"), status: :bad_request
       render("new", status: :bad_request)
     end
   end
@@ -31,7 +30,6 @@ class HistoriesController < ApplicationController
     if @history.update(history_params)
       redirect_to blance_histories_url(@blance), notice: t(".notice")
     else
-      redirect_to blance_histories_url(@blance), alert: t(".alert"), status: :bad_request
       render("edit", status: :bad_request)
     end
   end

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -4,6 +4,11 @@ class HistoriesController < ApplicationController
     @histories = @blance.histories
   end
 
+  def new
+    @blance = Blance.find(params[:blance_id])
+    @history = @blance.histories.build
+  end
+
   def edit
     @history = History.find(params[:id])
     @blance = @history.blance
@@ -16,6 +21,7 @@ class HistoriesController < ApplicationController
       redirect_to blance_histories_url(@blance), notice: t(".notice")
     else
       redirect_to blance_histories_url(@blance), alert: t(".alert"), status: :bad_request
+      render("new", status: :bad_request)
     end
   end
 
@@ -26,6 +32,7 @@ class HistoriesController < ApplicationController
       redirect_to blance_histories_url(@blance), notice: t(".notice")
     else
       redirect_to blance_histories_url(@blance), alert: t(".alert"), status: :bad_request
+      render("edit", status: :bad_request)
     end
   end
 

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -13,9 +13,9 @@ class HistoriesController < ApplicationController
     @blance = Blance.find(params[:blance_id])
     @history = @blance.histories.build(history_params)
     if @history.save
-      redirect_to blance_index_history_url(@blance), notice: t(".notice")
+      redirect_to blance_histories_url(@blance), notice: t(".notice")
     else
-      redirect_to blance_index_history_url(@blance), alert: t(".alert"), status: :bad_request
+      redirect_to blance_histories_url(@blance), alert: t(".alert"), status: :bad_request
     end
   end
 
@@ -23,9 +23,9 @@ class HistoriesController < ApplicationController
     @history = History.find(params[:id])
     @blance = @history.blance
     if @history.update(history_params)
-      redirect_to blance_index_history_url(@blance), notice: t(".notice")
+      redirect_to blance_histories_url(@blance), notice: t(".notice")
     else
-      redirect_to blance_index_history_url(@blance), alert: t(".alert"), status: :bad_request
+      redirect_to blance_histories_url(@blance), alert: t(".alert"), status: :bad_request
     end
   end
 
@@ -33,7 +33,7 @@ class HistoriesController < ApplicationController
     @history = History.find(params[:id])
     @blance = @history.blance
     @history.destroy
-    redirect_to blance_index_history_url(@blance), notice: t(".notice")
+    redirect_to blance_histories_url(@blance), notice: t(".notice")
   end
 
   private

--- a/app/views/blances/index.html.erb
+++ b/app/views/blances/index.html.erb
@@ -40,7 +40,7 @@
             <ul>
               <%= link_to(t(".show"), blance_path(blance)) %>
               <%= link_to(t(".edit"), edit_blance_path(blance)) %>
-              <%= link_to(t(".history"), blance_index_history_path(blance)) %>
+              <%= link_to(t(".history"), blance_histories_path(blance)) %>
             </ul>
           </td>
         </tr>

--- a/app/views/blances/index.html.erb
+++ b/app/views/blances/index.html.erb
@@ -40,6 +40,7 @@
             <ul>
               <%= link_to(t(".show"), blance_path(blance)) %>
               <%= link_to(t(".edit"), edit_blance_path(blance)) %>
+              <%= link_to(t(".history"), blance_index_history_path(blance)) %>
             </ul>
           </td>
         </tr>

--- a/app/views/blances/show.html.erb
+++ b/app/views/blances/show.html.erb
@@ -88,6 +88,9 @@
       <%= link_to @blance, data: { turbo_method: :delete, turbo_confirm: t(".confirm") }, class: "delete" do %>
         <%= icon("fa-regular", "trash-alt", t(".delete")) %>
       <% end %>
+      <%= link_to blance_index_history_path(@blance), class: "history" do %>
+        <%= icon("fa-solid", "book", t(".history")) %>
+      <% end %>
       <%= link_to blances_path, class: "back" do %>
         <%= icon("fa-solid", "arrow-left", t("defaults.back")) %>
       <% end %>

--- a/app/views/blances/show.html.erb
+++ b/app/views/blances/show.html.erb
@@ -88,7 +88,7 @@
       <%= link_to @blance, data: { turbo_method: :delete, turbo_confirm: t(".confirm") }, class: "delete" do %>
         <%= icon("fa-regular", "trash-alt", t(".delete")) %>
       <% end %>
-      <%= link_to blance_index_history_path(@blance), class: "history" do %>
+      <%= link_to blance_histories_path(@blance), class: "history" do %>
         <%= icon("fa-solid", "book", t(".history")) %>
       <% end %>
       <%= link_to blances_path, class: "back" do %>

--- a/app/views/histories/_form.html.erb
+++ b/app/views/histories/_form.html.erb
@@ -1,5 +1,7 @@
 <div class="histories__form">
   <%= form_with model: [@blance, history], local: true do |f| %>
+    <%= render 'shared/error_messages', object: f.object %>
+
     <div class="form_group">
       <%= f.label :game_count %>
       <%= f.number_field :game_count %>

--- a/app/views/histories/index.html.erb
+++ b/app/views/histories/index.html.erb
@@ -2,25 +2,25 @@
 <% provide(:button_text, t(".button_text")) %>
 
 <div class="histories__index">
-  <div class="list">
-    <% if @histories.any? %>
-      <table>
-        <thead>
-          <tr>
-            <th><%= History.human_attribute_name(:game_count) %></th>
-            <th><%= History.human_attribute_name(:chance) %></th>
-            <th><%= History.human_attribute_name(:investment) %></th>
-            <th><%= History.human_attribute_name(:memo) %></th>
-            <th><%= t(".operation") %></th>
-          </tr>
-        </thead>
-        <tbody>
-          <%= render partial: :history, collection: @histories %>
-        </tbody>
-      </table>
-    <% else %>
+  <% if @histories.any? %>
+    <table>
+      <thead>
+        <tr>
+          <th><%= History.human_attribute_name(:game_count) %></th>
+          <th><%= History.human_attribute_name(:chance) %></th>
+          <th><%= History.human_attribute_name(:investment) %></th>
+          <th><%= History.human_attribute_name(:memo) %></th>
+          <th><%= t(".operation") %></th>
+        </tr>
+      </thead>
+      <tbody>
+        <%= render partial: :history, collection: @histories %>
+      </tbody>
+    </table>
+  <% else %>
+    <div class="no_history">
       <p><%= t(".no_history") %></p>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
   <%= render "form", { history: @histories.build } %>
 </div>

--- a/app/views/histories/index.html.erb
+++ b/app/views/histories/index.html.erb
@@ -1,5 +1,4 @@
 <% content_for(:title, t(".title", date: l(@blance.date))) %>
-<% provide(:button_text, t(".button_text")) %>
 
 <div class="histories__index">
   <% if @histories.any? %>
@@ -22,5 +21,5 @@
       <p><%= t(".no_history") %></p>
     </div>
   <% end %>
-  <%= render "form", { history: @histories.build } %>
+  <%= link_to(t(".new_history"), new_blance_history_path, class: "new_history") %>
 </div>

--- a/app/views/histories/index.html.erb
+++ b/app/views/histories/index.html.erb
@@ -21,5 +21,7 @@
       <p><%= t(".no_history") %></p>
     </div>
   <% end %>
-  <%= link_to(t(".new_history"), new_blance_history_path, class: "new_history") %>
+  <div class="new_history">
+    <%= link_to(t(".new_history"), new_blance_history_path) %>
+  </div>
 </div>

--- a/app/views/histories/new.html.erb
+++ b/app/views/histories/new.html.erb
@@ -1,0 +1,6 @@
+<% content_for(:title, t(".title", date: l(@blance.date))) %>
+<% provide(:button_text, t(".button_text")) %>
+
+<div class="histories__new">
+  <%= render "form", { history: @history } %>
+</div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -13,6 +13,7 @@ ja:
       operation: "操作"
       show: "閲覧する"
       edit: "編集する"
+      history: "遊技履歴"
     new:
       title: "収支作成"
       button_text: "収支を作成"
@@ -26,6 +27,7 @@ ja:
       operation: "操作"
       edit: "編集する"
       delete: "削除する"
+      history: "遊技履歴"
       confirm: "本当に収支を削除してよろしいでしょうか？"
     create:
       notice: "収支を作成しました"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -47,6 +47,9 @@ ja:
       title: "%{date}の遊戯履歴"
       operation: "操作"
       no_history: "遊技履歴は保存されていません"
+      new_history: "遊技履歴を作成する"
+    new:
+      title: "%{date}の履歴作成"
       button_text: "遊技履歴を作成"
     edit:
       title: "%{date}の履歴編集"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,6 @@ Rails.application.routes.draw do
   get "/hello", to: "hello#index"
 
   resources :blances, path: "/syusi" do
-    resources :histories, only: %i[index edit create update destroy]
+    resources :histories, only: %i[index new edit create update destroy]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,6 @@ Rails.application.routes.draw do
   get "/hello", to: "hello#index"
 
   resources :blances, path: "/syusi" do
-    get "/history", to: "histories#index", as: :index_history
-    resources :histories, only: %i[edit create update destroy]
+    resources :histories, only: %i[index edit create update destroy]
   end
 end

--- a/test/controllers/histories_controller_test.rb
+++ b/test/controllers/histories_controller_test.rb
@@ -13,7 +13,7 @@ class HistoriesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get index" do
-    get blance_index_history_url @blance
+    get blance_histories_url @blance
     assert_response :success
     assert_select "title", @page_title + I18n.t("histories.index.title", date: I18n.l(@blance.date))
   end
@@ -44,7 +44,7 @@ class HistoriesControllerTest < ActionDispatch::IntegrationTest
       patch blance_history_url @blance, @history, params: { history: @history_hash }
       @history.reload
     end
-    assert_redirected_to blance_index_history_url(@blance)
+    assert_redirected_to blance_histories_url(@blance)
   end
 
   test "should return bad_request when patch update" do
@@ -60,6 +60,6 @@ class HistoriesControllerTest < ActionDispatch::IntegrationTest
     assert_difference("History.count", -1) do
       delete blance_history_url @blance, @history
     end
-    assert_redirected_to blance_index_history_url(@blance)
+    assert_redirected_to blance_histories_url(@blance)
   end
 end

--- a/test/system/blances_test.rb
+++ b/test/system/blances_test.rb
@@ -26,6 +26,7 @@ class BlancesTest < ApplicationSystemTestCase
       assert_text I18n.t("blances.index.operation")
       assert_link I18n.t("blances.index.show"), href: blance_path(blance)
       assert_link I18n.t("blances.index.edit"), href: edit_blance_path(blance)
+      assert_link I18n.t("blances.index.history"), href: blance_histories_path(blance)
     end
   end
 
@@ -53,6 +54,7 @@ class BlancesTest < ApplicationSystemTestCase
     assert_text I18n.t("blances.show.etc")
     assert_link I18n.t("blances.show.edit"), href: edit_blance_path(@blance)
     assert_link I18n.t("blances.show.delete"), href: blance_path(@blance)
+    assert_link I18n.t("blances.show.history"), href: blance_histories_path(@blance)
     assert_link I18n.t("defaults.back"), href: blances_path
   end
 

--- a/test/system/histories_test.rb
+++ b/test/system/histories_test.rb
@@ -23,6 +23,7 @@ class HistoriesTest < ApplicationSystemTestCase
       assert_link I18n.t("histories.history.edit"), href: edit_blance_history_path(@blance, history)
       assert_link I18n.t("histories.history.destroy"), href: blance_history_path(@blance, history)
     end
+    assert_link I18n.t("histories.index.new_history"), href: new_blance_history_path(@blance)
   end
 
   test "creating a History" do
@@ -31,14 +32,14 @@ class HistoriesTest < ApplicationSystemTestCase
     visit new_blance_history_url(@blance)
 
     # invalid input
-    click_on I18n.t("histories.index.button_text")
-    assert_selector "div#flash_alert"
+    click_on I18n.t("histories.new.button_text")
+    assert_selector "div#error_explanation"
     # valid input
     fill_in I18n.t("activerecord.attributes.history.game_count"), with: @history.game_count
     fill_in I18n.t("activerecord.attributes.history.chance"), with: @history.chance
     fill_in I18n.t("activerecord.attributes.history.investment"), with: @history.investment
     fill_in I18n.t("activerecord.attributes.history.memo"), with: @history.memo
-    click_on I18n.t("histories.index.button_text")
+    click_on I18n.t("histories.new.button_text")
     # check redirect
     assert_selector "div#flash_notice", text: I18n.t("histories.create.notice")
     assert_text @history.memo
@@ -46,15 +47,15 @@ class HistoriesTest < ApplicationSystemTestCase
 
   test "updating a History" do
     @history = @histories.first
-    @history.memo = "testtest"
+    @history.game_count = "999999"
     visit edit_blance_history_url(@blance, @history)
 
     # invalid input
     fill_in I18n.t("activerecord.attributes.history.game_count"), with: ""
     click_on I18n.t("histories.edit.button_text")
-    assert_selector "div#flash_alert"
+    assert_selector "div#error_explanation"
     # valid input
-    fill_in I18n.t("activerecord.attributes.history.memo"), with: @history.memo
+    fill_in I18n.t("activerecord.attributes.history.game_count"), with: @history.game_count
     click_on I18n.t("histories.edit.button_text")
     # check redirect
     assert_selector "div#flash_notice", text: I18n.t("histories.update.notice")

--- a/test/system/histories_test.rb
+++ b/test/system/histories_test.rb
@@ -8,10 +8,10 @@ class HistoriesTest < ApplicationSystemTestCase
 
   test "visiting the index" do
     # no history
-    visit blance_index_history_url(blances(:most_recent))
+    visit blance_histories_url(blances(:most_recent))
     assert_text I18n.t("histories.index.no_history")
     # has history
-    visit blance_index_history_url(@blance)
+    visit blance_histories_url(@blance)
     excepted_columns = %w[id created_at updated_at blance_id]
     @histories.each do |history|
       history.attributes.each do |k, v|
@@ -28,7 +28,7 @@ class HistoriesTest < ApplicationSystemTestCase
   test "creating a History" do
     @history = @histories.first
     @history.memo = "testtest"
-    visit blance_index_history_url(@blance)
+    visit new_blance_history_url(@blance)
 
     # invalid input
     click_on I18n.t("histories.index.button_text")
@@ -64,7 +64,7 @@ class HistoriesTest < ApplicationSystemTestCase
   test "destroying a History" do
     @blance = blances(:two)
     @history = @blance.histories.first
-    visit blance_index_history_url(@blance)
+    visit blance_histories_url(@blance)
 
     click_on I18n.t("histories.history.destroy")
     assert_match page.driver.browser.switch_to.alert.text, I18n.t("histories.history.confirm")


### PR DESCRIPTION
**主な変更内容**

- 遊技履歴の一覧、編集フォームにスタイルを追加
- `HistoriesController`に`new`アクションを追加

**イシュー番号**

Issue: #45

**チェックリスト**

- [x] 遊技履歴一覧ページのスタイル
- [x] 遊技履歴編集フォームページのスタイル
- [x] 遊技履歴の作成フロー
- [x] 遊技履歴作成フォームページのスタイル
