### PR TITLE
収支一覧のスタイルの修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -17,6 +17,7 @@
 @import "font-awesome";
 
 @import "variables";
+@import "etc";
 
 @import "layouts";
 @import "shared";

--- a/app/assets/stylesheets/blances.scss
+++ b/app/assets/stylesheets/blances.scss
@@ -6,6 +6,9 @@
 .blances__index {
   padding: 1rem;
   .list {
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
   }
   .new_blance {
     margin-top: 1em;
@@ -23,6 +26,7 @@
   padding: 1rem;
 
   table {
+    table-layout: fixed;
     width: 100%;
     border: 1px solid $color-border-primary;
     border-collapse: collapse;
@@ -106,29 +110,77 @@
 // blance
 //
 .blances__blance {
+  font-size: 0.8em;
+  display: grid;
+  grid-template-areas:
+    "date date"
+    "result investment"
+    "result recovery"
+    "store name"
+    "links links";
+  grid-template-columns: 200px 1fr;
+  border: 1px solid $color-border-primary;
   > * {
+    color: $color-text-secondary;
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    padding: 0.5em 0.25em;
     span {
+      color: $color-text-primary;
+      padding-left: 0.5em;
     }
   }
   .date {
+    grid-area: date;
+    font-weight: bold;
+    padding-left: 1em;
+    color: $color-text-primary;
+    background-color: $color-background-secondary;
   }
   .result {
+    grid-area: result;
+    font-size: 1.6em;
+    line-height: 2;
+    background-color: $color-background-blue;
+    padding-left: 0.5em;
+    &.zero {
+      color: $color-text-primary;
+    }
     &.plus {
+      color: $color-text-success;
     }
     &.minus {
+      color: $color-text-alert;
     }
   }
   .investment {
+    grid-area: investment;
+    border-bottom: 1px solid $color-border-primary;
   }
   .recovery {
+    grid-area: recovery;
   }
   .name {
+    grid-area: name;
+    font-size: 0.9em;
   }
   .store {
+    grid-area: store;
+    font-size: 0.9em;
   }
   .links {
+    grid-area: links;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+    border-top: 1px solid $color-border-primary;
     a {
+      color: $color-text-link;
+      text-decoration: none;
       &:hover {
+        text-decoration: underline;
       }
     }
   }

--- a/app/assets/stylesheets/blances.scss
+++ b/app/assets/stylesheets/blances.scss
@@ -3,9 +3,13 @@
 //
 // index
 //
-.blances__list {
-  font-size: 0.8rem;
+.blances__index {
   padding: 1rem;
+  .list {
+  }
+  .new_blance {
+    margin-top: 1em;
+  }
 }
 
 //
@@ -93,6 +97,38 @@
           border-bottom-left-radius: 0.5em;
           border-bottom-right-radius: 0.5em;
         }
+      }
+    }
+  }
+}
+
+//
+// blance
+//
+.blances__blance {
+  > * {
+    span {
+    }
+  }
+  .date {
+  }
+  .result {
+    &.plus {
+    }
+    &.minus {
+    }
+  }
+  .investment {
+  }
+  .recovery {
+  }
+  .name {
+  }
+  .store {
+  }
+  .links {
+    a {
+      &:hover {
       }
     }
   }

--- a/app/assets/stylesheets/blances.scss
+++ b/app/assets/stylesheets/blances.scss
@@ -5,53 +5,7 @@
 //
 .blances__list {
   font-size: 0.8rem;
-  overflow-x: auto;
   padding: 1rem;
-
-  table {
-    width: max-content;
-    border-collapse: collapse;
-
-    th,
-    td {
-      min-width: 80px;
-      max-width: 200px;
-      padding: 0.5em;
-      border: 1px solid $color-border-primary;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-    }
-    td:last-child {
-      padding: 0;
-
-      ul {
-        display: flex;
-        flex-direction: column;
-        margin: 0;
-        padding: 0;
-        line-height: 2;
-
-        a {
-          color: $color-text-link;
-          text-decoration: none;
-          padding: 0.25em 0.5em;
-
-          &:hover {
-            text-decoration: underline;
-          }
-          &:nth-child(even) {
-            background-color: $color-background-secondary;
-            border-top: 1px solid $color-border-primary;
-            border-bottom: 1px solid $color-border-primary;
-            &:last-child {
-              border-bottom: none;
-            }
-          }
-        }
-      }
-    }
-  }
 }
 
 //

--- a/app/assets/stylesheets/etc.scss
+++ b/app/assets/stylesheets/etc.scss
@@ -1,0 +1,36 @@
+.creation-link-btn {
+  appearance: button;
+  background-color: #000;
+  background-image: none;
+  border: 1px solid #000;
+  border-radius: 4px;
+  box-shadow: #fff 4px 4px 0 0,#000 4px 4px 0 1px;
+  box-sizing: border-box;
+  color: #fff;
+  cursor: pointer;
+  display: inline-block;
+  font-family: ITCAvantGardeStd-Bk,Arial,sans-serif;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+  margin: 0 5px 10px 0;
+  overflow: visible;
+  padding: 12px 12px;
+  text-align: center;
+  text-transform: none;
+  touch-action: manipulation;
+  user-select: none;
+  -webkit-user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  text-decoration: none;
+  &:hover {
+    box-shadow: rgba(0, 0, 0, .125) 0 3px 5px inset;
+    outline: 0;
+  }
+  &:not([disabled]):hover {
+    box-shadow: #fff 2px 2px 0 0, #000 2px 2px 0 1px;
+    transform: translate(2px, 2px);
+  }
+}
+

--- a/app/assets/stylesheets/histories.scss
+++ b/app/assets/stylesheets/histories.scss
@@ -54,41 +54,6 @@
   }
   .new_history {
     margin-top: 1rem;
-    a {
-      appearance: button;
-      background-color: #000;
-      background-image: none;
-      border: 1px solid #000;
-      border-radius: 4px;
-      box-shadow: #fff 4px 4px 0 0,#000 4px 4px 0 1px;
-      box-sizing: border-box;
-      color: #fff;
-      cursor: pointer;
-      display: inline-block;
-      font-family: ITCAvantGardeStd-Bk,Arial,sans-serif;
-      font-size: 14px;
-      font-weight: 400;
-      line-height: 20px;
-      margin: 0 5px 10px 0;
-      overflow: visible;
-      padding: 12px 12px;
-      text-align: center;
-      text-transform: none;
-      touch-action: manipulation;
-      user-select: none;
-      -webkit-user-select: none;
-      vertical-align: middle;
-      white-space: nowrap;
-      text-decoration: none;
-      &:hover {
-        box-shadow: rgba(0, 0, 0, .125) 0 3px 5px inset;
-        outline: 0;
-      }
-      &:not([disabled]):hover {
-        box-shadow: #fff 2px 2px 0 0, #000 2px 2px 0 1px;
-        transform: translate(2px, 2px);
-      }
-    }
   }
 }
 

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -3,9 +3,11 @@ $color-text-secondary: #777777;
 $color-text-notice: #1e90ff;
 $color-text-alert: #dc143c;
 $color-text-link: #1e90ff;
+$color-text-success: #32cd32;
 
 $color-background-primary: #ffffff;
 $color-background-secondary: #f5f5f5;
+$color-background-blue: #f0f8ff;
 $color-background-dark: #333333;
 $color-background-notice: #e0ffff;
 $color-background-alert: #ffc0cb;

--- a/app/javascript/controllers/blances_controller.js
+++ b/app/javascript/controllers/blances_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="blances"
+export default class extends Controller {
+  static targets = ["result"];
+
+  connect() {
+    const result = this.resultTarget;
+    const resultNum = Number(result.textContent);
+    if (resultNum === 0) {
+      this.resultTarget.classList.add("zero");
+    } else if (resultNum > 0) {
+      result.textContent = `+${resultNum}`;
+      this.resultTarget.classList.add("plus");
+    } else {
+      this.resultTarget.classList.add("minus");
+    }
+  }
+}

--- a/app/models/blance.rb
+++ b/app/models/blance.rb
@@ -33,6 +33,20 @@ class Blance < ApplicationRecord
     result.round
   end
 
+  def total_investment_money
+    investment_money = self.investment_money.to_i
+    rate = self.rate.to_f
+    investment_saving = self.investment_saving.to_i * rate
+    (investment_money + investment_saving).round
+  end
+
+  def total_recovery_money
+    recovery_money = self.recovery_money.to_i
+    rate = self.rate.to_f
+    recovery_saving = self.recovery_saving.to_i * rate
+    (recovery_money + recovery_saving).round
+  end
+
   def sort_histories
     return histories if history_order.order.blank?
 

--- a/app/views/blances/_blance.html.erb
+++ b/app/views/blances/_blance.html.erb
@@ -1,6 +1,6 @@
 <div class="blances__blance" data-controller="blances">
   <div class="date"><%= t(".date", date: l(blance.date)) %></div>
-  <div class="result" data-target="blances.result"><%= blance.result %></div>
+  <div class="result" data-blances-target="result"><%= blance.result %></div>
   <div class="investment"><%= t(".investment") %><span><%= blance.total_investment_money %></span></div>
   <div class="recovery"><%= t(".recovery") %><span><%= blance.total_recovery_money %></span></div>
   <div class="name"><%= t(".name") %><span><%= blance.name %></span></div>

--- a/app/views/blances/_blance.html.erb
+++ b/app/views/blances/_blance.html.erb
@@ -1,0 +1,10 @@
+日付：<%= l(blance.date) %>
+結果：<%= blance.result %>円
+投資合計：<%= blance.total_investment_money %>円
+回収合計：<%= blance.total_recovery_money %>円
+機種名：<%= blance.name %>
+店舗名：<%= blance.store %>
+<%= link_to t(".show"), blance %>
+<%= link_to t(".edit"), edit_blance_path(blance) %>
+<%= link_to t(".destroy"), @blance, data: { turbo_method: :delete, turbo_confirm: t(".confirm") } %>
+<%= link_to t(".history"), blance_histories_path(blance) %>

--- a/app/views/blances/_blance.html.erb
+++ b/app/views/blances/_blance.html.erb
@@ -1,10 +1,14 @@
-日付：<%= l(blance.date) %>
-結果：<%= blance.result %>円
-投資合計：<%= blance.total_investment_money %>円
-回収合計：<%= blance.total_recovery_money %>円
-機種名：<%= blance.name %>
-店舗名：<%= blance.store %>
-<%= link_to t(".show"), blance %>
-<%= link_to t(".edit"), edit_blance_path(blance) %>
-<%= link_to t(".destroy"), @blance, data: { turbo_method: :delete, turbo_confirm: t(".confirm") } %>
-<%= link_to t(".history"), blance_histories_path(blance) %>
+<div class="blances__blance" data-controller="blances">
+  <div class="date"><%= t(".date", date: l(blance.date)) %></div>
+  <div class="result" data-target="blances.result"><%= blance.result %></div>
+  <div class="investment"><%= t(".investment") %><span><%= blance.total_investment_money %></span></div>
+  <div class="recovery"><%= t(".recovery") %><span><%= blance.total_recovery_money %></span></div>
+  <div class="name"><%= t(".name") %><span><%= blance.name %></span></div>
+  <div class="store"><%= t(".store") %><span><%= blance.store %></span></div>
+  <div class="links">
+    <%= link_to t(".show"), blance %>
+    <%= link_to t(".edit"), edit_blance_path(blance) %>
+    <%= link_to t(".destroy"), blance, data: { turbo_method: :delete, turbo_confirm: t(".confirm") } %>
+    <%= link_to t(".history"), blance_histories_path(blance) %>
+  </div>
+</div>

--- a/app/views/blances/index.html.erb
+++ b/app/views/blances/index.html.erb
@@ -2,12 +2,13 @@
 
 <% content_for(:title, t(".title")) %>
 
-<div class="blances__list">
-  <pre>
-  <code>
-<% @blances.each do |blance| %>
-<%= render "blance", blance: blance %>
-<% end %>
-  </code>
-  </pre>
+<div class="blances__index">
+  <div class="list">
+    <% @blances.each do |blance| %>
+      <%= render "blance", blance: blance %>
+    <% end %>
+  </div>
+  <div class="new_blance">
+    <%= link_to t(".new_blance"), new_blance_path %>
+  </div>
 </div>

--- a/app/views/blances/index.html.erb
+++ b/app/views/blances/index.html.erb
@@ -9,6 +9,6 @@
     <% end %>
   </div>
   <div class="new_blance">
-    <%= link_to t(".new_blance"), new_blance_path %>
+    <%= link_to t(".new_blance"), new_blance_path, class: "creation-link-btn" %>
   </div>
 </div>

--- a/app/views/blances/index.html.erb
+++ b/app/views/blances/index.html.erb
@@ -3,48 +3,11 @@
 <% content_for(:title, t(".title")) %>
 
 <div class="blances__list">
-  <table>
-    <thead>
-      <tr>
-        <th><%= Blance.human_attribute_name(:date) %></th>
-        <th><%= Blance.human_attribute_name(:category) %></th>
-        <th><%= Blance.human_attribute_name(:investment_money) %></th>
-        <th><%= Blance.human_attribute_name(:recovery_money) %></th>
-        <th><%= Blance.human_attribute_name(:investment_saving) %></th>
-        <th><%= Blance.human_attribute_name(:recovery_saving) %></th>
-        <th><%= Blance.human_attribute_name(:rate) %></th>
-        <th><%= Blance.human_attribute_name(:result) %></th>
-        <th><%= Blance.human_attribute_name(:name) %></th>
-        <th><%= Blance.human_attribute_name(:store) %></th>
-        <th><%= Blance.human_attribute_name(:created_at) %></th>
-        <th><%= Blance.human_attribute_name(:updated_at) %></th>
-        <th><%= t(".operation") %></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @blances.each do |blance| %>
-        <tr>
-          <td><%= l(blance.date) %></td>
-          <td><%= blance.category %></td>
-          <td><%= blance.investment_money || 0 %></td>
-          <td><%= blance.recovery_money || 0 %></td>
-          <td><%= blance.investment_saving || 0 %></td>
-          <td><%= blance.recovery_saving || 0 %></td>
-          <td><%= blance.rate %></td>
-          <td><%= blance.result || 0 %></td>
-          <td><%= blance.name %></td>
-          <td><%= blance.store %></td>
-          <td><%= t("defaults.ago", time: time_ago_in_words(blance.created_at)) %></td>
-          <td><%= t("defaults.ago", time: time_ago_in_words(blance.updated_at)) %></td>
-          <td>
-            <ul>
-              <%= link_to(t(".show"), blance_path(blance)) %>
-              <%= link_to(t(".edit"), edit_blance_path(blance)) %>
-              <%= link_to(t(".history"), blance_histories_path(blance)) %>
-            </ul>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+  <pre>
+  <code>
+<% @blances.each do |blance| %>
+<%= render "blance", blance: blance %>
+<% end %>
+  </code>
+  </pre>
 </div>

--- a/app/views/histories/index.html.erb
+++ b/app/views/histories/index.html.erb
@@ -22,6 +22,6 @@
     </div>
   <% end %>
   <div class="new_history">
-    <%= link_to(t(".new_history"), new_blance_history_path) %>
+    <%= link_to(t(".new_history"), new_blance_history_path, class: "creation-link-btn") %>
   </div>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,6 +6,12 @@ ja:
     back: "戻る"
   blances:
     blance:
+      date: "%{date}の収支"
+      result: ""
+      investment: "投資合計"
+      recovery: "回収合計"
+      name: "機種"
+      store: "店舗"
       show: "閲覧する"
       edit: "編集する"
       destroy: "削除する"
@@ -16,6 +22,7 @@ ja:
       button_text: "収支を編集"
     index:
       title: "収支一覧"
+      new_blance: "収支を作成する"
     new:
       title: "収支作成"
       button_text: "収支を作成"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -5,15 +5,17 @@ ja:
     updated: "%{date}に更新"
     back: "戻る"
   blances:
+    blance:
+      show: "閲覧する"
+      edit: "編集する"
+      destroy: "削除する"
+      confirm: "本当に収支を削除してよろしいでしょうか？"
+      history: "遊技履歴"
     edit:
       title: "%{date}の収支編集"
       button_text: "収支を編集"
     index:
       title: "収支一覧"
-      operation: "操作"
-      show: "閲覧する"
-      edit: "編集する"
-      history: "遊技履歴"
     new:
       title: "収支作成"
       button_text: "収支を作成"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
 
   selenium:
     image: seleniarm/standalone-chromium
-    shm_size: 512m
+    shm_size: 2g
     ports:
       - "7900:7900"
 

--- a/test/models/blance_test.rb
+++ b/test/models/blance_test.rb
@@ -145,6 +145,42 @@ class BlanceTest < ActiveSupport::TestCase
     assert_equal 0, blance.result
   end
 
+  test "total_investment_money() should be correct (rate: 21.73)" do
+    blance = Blance.new(
+      investment_money: 10_000,
+      investment_saving: 460,
+      rate: 21.73
+    )
+    assert_equal 19_996, blance.total_investment_money
+  end
+
+  test "total_investment_money() should be return 0" do
+    blance = Blance.new(
+      investment_money: nil,
+      investment_saving: nil,
+      rate: nil
+    )
+    assert_equal 0, blance.total_investment_money
+  end
+
+  test "total_recovery_money() should be correct (rate: 21.73)" do
+    blance = Blance.new(
+      recovery_money: 10_000,
+      recovery_saving: 460,
+      rate: 21.73
+    )
+    assert_equal 19_996, blance.total_recovery_money
+  end
+
+  test "total_recovery_money() should be return 0" do
+    blance = Blance.new(
+      recovery_money: nil,
+      recovery_saving: nil,
+      rate: nil
+    )
+    assert_equal 0, blance.total_recovery_money
+  end
+
   test "sort_histories() returns an arbitrarily ordered histories" do
     order = @blance.history_order.order
     assert_equal order.split(",").map(&:to_i), @blance.sort_histories.map(&:id)

--- a/test/system/blances_test.rb
+++ b/test/system/blances_test.rb
@@ -8,25 +8,25 @@ class BlancesTest < ApplicationSystemTestCase
   test "visiting the index" do
     visit blances_url
 
-    excepted_columns = %w[id note]
+    # excepted_columns = %w[id note]
     Blance.find_each do |blance|
-      blance.attributes.each do |k, v|
-        next if excepted_columns.include?(k)
+    #   blance.attributes.each do |k, v|
+    #     next if excepted_columns.include?(k)
 
-        assert_selector "th", text: Blance.human_attribute_name(k)
-        case k
-        when "date"
-          assert_selector "td", text: I18n.l(v)
-        when "created_at", "updated_at"
-          assert_selector "td", text: time_ago_in_words(v)
-        else
-          assert_selector "td", text: v
-        end
-      end
-      assert_text I18n.t("blances.index.operation")
-      assert_link I18n.t("blances.index.show"), href: blance_path(blance)
-      assert_link I18n.t("blances.index.edit"), href: edit_blance_path(blance)
-      assert_link I18n.t("blances.index.history"), href: blance_histories_path(blance)
+    #     assert_selector "th", text: Blance.human_attribute_name(k)
+    #     case k
+    #     when "date"
+    #       assert_selector "td", text: I18n.l(v)
+    #     when "created_at", "updated_at"
+    #       assert_selector "td", text: time_ago_in_words(v)
+    #     else
+    #       assert_selector "td", text: v
+    #     end
+    #   end
+    #   assert_text I18n.t("blances.index.operation")
+      assert_link I18n.t("blances.blance.show"), href: blance_path(blance)
+      assert_link I18n.t("blances.blance.edit"), href: edit_blance_path(blance)
+      assert_link I18n.t("blances.blance.history"), href: blance_histories_path(blance)
     end
   end
 

--- a/test/system/blances_test.rb
+++ b/test/system/blances_test.rb
@@ -8,26 +8,23 @@ class BlancesTest < ApplicationSystemTestCase
   test "visiting the index" do
     visit blances_url
 
-    # excepted_columns = %w[id note]
     Blance.find_each do |blance|
-    #   blance.attributes.each do |k, v|
-    #     next if excepted_columns.include?(k)
-
-    #     assert_selector "th", text: Blance.human_attribute_name(k)
-    #     case k
-    #     when "date"
-    #       assert_selector "td", text: I18n.l(v)
-    #     when "created_at", "updated_at"
-    #       assert_selector "td", text: time_ago_in_words(v)
-    #     else
-    #       assert_selector "td", text: v
-    #     end
-    #   end
-    #   assert_text I18n.t("blances.index.operation")
+      assert_text I18n.t("blances.blance.date", date: I18n.l(blance.date))
+      blance.result.positive? ? assert_text("+#{blance.result}") : assert_text(blance.result)
+      assert_text blance.total_investment_money
+      assert_text blance.total_recovery_money
+      assert_text blance.store || ""
+      assert_text blance.name || ""
       assert_link I18n.t("blances.blance.show"), href: blance_path(blance)
       assert_link I18n.t("blances.blance.edit"), href: edit_blance_path(blance)
+      assert_link I18n.t("blances.blance.destroy"), href: blance_path(blance)
       assert_link I18n.t("blances.blance.history"), href: blance_histories_path(blance)
     end
+    assert_text I18n.t("blances.blance.investment")
+    assert_text I18n.t("blances.blance.recovery")
+    assert_text I18n.t("blances.blance.name")
+    assert_text I18n.t("blances.blance.store")
+    assert_link I18n.t("blances.index.new_blance"), href: new_blance_path
   end
 
   test "visiting the show" do


### PR DESCRIPTION
**主な変更内容**

- 収支一覧ページのスタイルをテーブル形式からリスト形式に変更
- 収支一覧ページにある収支作成リンクボタンのスタイルを変更

**イシュー番号**

Issue: #50 #52 

**チェックリスト**

- [x] 収支一覧ページのスタイル
- [x] 収支一覧ページの作成ボタンのスタイル
